### PR TITLE
Updated to minecraft version: 1.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,12 +88,12 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modApi("me.shedaniel.cloth:cloth-config-fabric:11.1.106") {
+	modApi("me.shedaniel.cloth:cloth-config-fabric:15.0.127") {
 		exclude(group: "net.fabricmc.fabric-api")
 	}
 
 	// Mod Menu
-	modImplementation("com.terraformersmc:modmenu:7.2.1") {
+	modImplementation("com.terraformersmc:modmenu:11.0.1") {
 		transitive = false
 	}
 
@@ -110,7 +110,7 @@ dependencies {
 	// Uncomment the following line to enable the deprecated Fabric API modules.
 	// These are included in the Fabric API production distribution and allow you to update your mod to the latest modules at a later more convenient time.
 
-	// modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_version}"
+	 modImplementation "net.fabricmc.fabric-api:fabric-api-deprecated:${project.fabric_version}"
 }
 remapJar.dependsOn shadowJar
 remapJar {
@@ -125,7 +125,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 17
+	it.options.release = 21
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,9 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.10
-loader_version=0.14.22
+minecraft_version=1.21
+yarn_mappings=1.21+build.9
+loader_version=0.15.11
 
 # Mod Properties
 mod_version=2.1.0
@@ -14,4 +14,4 @@ maven_group=me.kokostrike.creatortools
 archives_base_name=creatortools
 
 # Dependencies
-fabric_version=0.86.1+1.20.1
+fabric_version=0.102.0+1.21

--- a/src/main/java/me/kokostrike/creatortools/mixin/ChatMixin.java
+++ b/src/main/java/me/kokostrike/creatortools/mixin/ChatMixin.java
@@ -11,13 +11,11 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 
-
 @Mixin(ChatHud.class)
 
 public class ChatMixin {
     @Unique
     private final ConfigSettings configSettings = ConfigSettingsProvider.getConfigSettings();
-
 
     @ModifyVariable(
             method = "addMessage(Lnet/minecraft/text/Text;Lnet/minecraft/network/message/MessageSignatureData;ILnet/minecraft/client/gui/hud/MessageIndicator;Z)V",
@@ -27,27 +25,13 @@ public class ChatMixin {
     private Text replaceChatMessage(Text message, Text parameterMessage, MessageSignatureData data, int ticks, MessageIndicator indicator, boolean refreshing) {
         // If the chat filter is disabled, return the message as is.
         if (!configSettings.isChatFilter()) return message;
-        // If we're refreshing, we have probably already modified the message, therefore we don't want to do anything.
 
+        // If we're refreshing, we have probably already modified the message, therefore we don't want to do anything.
         if (refreshing) {
             return message;
         }
 
-        return filter(message);
-    }
-
-    @Unique
-    private Text filter(Text message) {
-        // If there are no words to filter, return the message as is.
-        if (configSettings.getChatFilterMessages().isEmpty()) return message;
-        // If the message doesn't contain any of the words to filter, return the message as is.
-        if (configSettings.getChatFilterMessages().stream().noneMatch(message.getString()::contains)) return message;
-
-        // Replace the filterd words with asterisks.
-        for (String word : configSettings.getChatFilterMessages()) {
-            message = Text.of(message.getString().replaceAll("(?i)" + word, "*".repeat(word.length())));
-        }
+        // Remove the Streamer Mode functionality by always returning the original message
         return message;
     }
-
 }

--- a/src/main/resources/creatortools.mixins.json
+++ b/src/main/resources/creatortools.mixins.json
@@ -3,7 +3,7 @@
 	"package": "me.kokostrike.creatortools.mixin",
 	"compatibilityLevel": "JAVA_21",
 	"mixins": [
-		//"ChatMixin"
+		"ChatMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1

--- a/src/main/resources/creatortools.mixins.json
+++ b/src/main/resources/creatortools.mixins.json
@@ -1,9 +1,9 @@
 {
 	"required": true,
 	"package": "me.kokostrike.creatortools.mixin",
-	"compatibilityLevel": "JAVA_17",
+	"compatibilityLevel": "JAVA_21",
 	"mixins": [
-		"ChatMixin"
+		//"ChatMixin"
 	],
 	"injectors": {
 		"defaultRequire": 1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -35,9 +35,9 @@
 		"creatortools.mixins.json"
 	],
 	"depends": {
-		"fabricloader": ">=0.14.20",
-		"minecraft": "~1.20.1",
-		"java": ">=17",
+		"fabricloader": ">=0.15.11",
+		"minecraft": "~1.21",
+		"java": ">=21",
 		"fabric-api": "*",
 		"cloth-config2": "*"
 	},


### PR DESCRIPTION
It now supports minecraft version 1.21 but it has some drawback too:

1. Anything related to appear as toast message will crash game.
2. Only checked on yt chat and cmd and it works fine.
3. Haven't checked streamlab donations and elements.
4. Disabled Chat.mixin.class , cause it causing the issue with new version of minecraft.